### PR TITLE
File copy fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import string
 import glob
 import traceback
 import json
-from distutils.dir_util import copy_tree
+#from distutils.dir_util import copy_tree
 from datetime import datetime
 import time
 import sys
@@ -211,7 +211,7 @@ def main():
 										ydl.download([url])
 									else:
 										print("Warning! This video is streaming live, it will be skipped")
-										skip_download = True
+						    			skip_download = True
 
 							except Exception as e:
 								print("Failed to Download")

--- a/main.py
+++ b/main.py
@@ -211,7 +211,7 @@ def main():
 										ydl.download([url])
 									else:
 										print("Warning! This video is streaming live, it will be skipped")
-						    			skip_download = True
+										skip_download = True
 
 							except Exception as e:
 								print("Failed to Download")

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import time
 import sys
 from pprint import pprint
 
+
 # Support for both python 2 and 3
 if sys.version_info[0] == 3:
 	from urllib.request import urlopen
@@ -107,7 +108,8 @@ def get_icons(channel, chid, overwrite=False):
 						f.write(request.urlopen(icon_url).read())
 
 					print("Moving Icon...")
-					shutil.move('poster.jpg', destinationDir + 'poster.jpg')
+					#shutil.move('poster.jpg', destinationDir + 'poster.jpg')
+					safecopy('poster.jpg', destinationDir + 'poster.jpg')
 				except Exception as e:
 					print("An error occured moving Icon")
 					print("Error dump in error.log")
@@ -119,6 +121,14 @@ def get_icons(channel, chid, overwrite=False):
 						pprint(globals(), stream=f)
 						pprint(locals(), stream=f)
 			print()
+
+def safecopy(src, dst):
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src))
+    shutil.copyfile(src, dst)
+
+
+
 
 def main():
 	global START_HOUR
@@ -239,7 +249,12 @@ def main():
 									os.makedirs(destinationDir)
 								try:
 									print("Moving Folder...")
-									copy_tree(sourceDir, destinationDir)
+									#copy_tree(sourceDir, destinationDir)
+
+									#iterate through source and copy each
+									for filename in os.listdir(sourceDir):
+										safecopy(os.path.join(sourceDir, filename), destinationDir)
+
 									shutil.rmtree(sourceDir, ignore_errors=True)
 									#shutil.move(videoName, destination + destVideoName)
 									#shutil.move(thumbName, destination + destThumbName)


### PR DESCRIPTION
This really just recodes to avoid some side effects of the larger shutil calls.  This specifically fixes what I am seeing when moving data across mounts in freebsd.  I assume this also applies to other O/S's.  Some light reading can be found at https://stackoverflow.com/questions/26654097/move-from-local-linux-folder-to-a-windows-share-mounted-with-cifs 

I also commented out one import thats not needed, you can remove entirely if you agree on that.
