### PR TITLE
Crom compatibility fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -278,6 +278,7 @@ class scheduling:
             logging.info("Evaluating run once schedule mode")
             if self.did_i_just_complete_run:
                 logging.info("  Just completed run, ending")
+                sys.exit(0)
                 #break
             else:
                 logging.info("  Starting run once")

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import json
 #from distutils.dir_util import copy_tree
 from datetime import datetime
 import time
-import sys, getopt
+import fcntl, sys, getopt
 from pprint import pprint
 import logging
 import re
@@ -487,11 +487,26 @@ def main():
 
 
 if __name__ == "__main__":
+    # change working directory to the location of main.py
+    abspath = os.path.abspath(__file__)
+    dname = os.path.dirname(abspath)
+    os.chdir(dname)
+    
     if not os.path.isfile('main.log'):
         open('main.log', 'a').close()
     loggingFile = open('main.log', 'a', encoding='utf-8')
     logging.basicConfig(stream=loggingFile, level=logging.DEBUG, format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
     logging.info("Program main.py started")
+
+    # check if another instance is running
+    pid_file = 'program.pid'
+    fp = open(pid_file, 'w')
+    try:
+        fcntl.lockf(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except IOError:
+        print("Another instance is running")
+        logging.error("Another instance is running")
+        sys.exit(0)
 
     logFileName = "data/log.txt"
 

--- a/main.py
+++ b/main.py
@@ -126,7 +126,7 @@ def get_icons(channel, chid, overwrite=False):
 
     #print("Downloading Icons....")
     if len(channel) == 0:
-		print("Error youtubeData.xml file empty please run setup.py to fix")
+        print("Error youtubeData.xml file empty please run setup.py to fix")
 
     else:
         for j in range(0, len(channel)):


### PR DESCRIPTION
I added some extra features to improve the compatibility with running as a cron job. First, the working directory was wherever the command was run, not where main.py resides. This is now fixed.

I also fixed another possible issue which is multiple instances running from a cron job. The script will now notify you that another instance is running and exit gracefully.

Also apparently the script wasn't exiting if set to RUN_ONCE. This is now fixed.

Some of the display output is messy, but I didn't want to change more than I had to. For example, it displays the run number before it checks to exit, but it was like this before I touched it.

(I'm not sure why it's trying to merge the tabs to spaces commit again. I'm pretty new to doing pull requests)